### PR TITLE
Revise SPDX license code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "library",
   "description": "Libraries to help developers express architectural abstractions in PHP code",
   "homepage": "https://xmolecules.org/",
-  "license": "Apache",
+  "license": "Apache-2.0",
   "authors": [
     {
       "name": "Henning Schwentner",


### PR DESCRIPTION
According to the [SPDX License List](https://spdx.org/licenses/) "Apache" is not the correct license code for the Apache 2.0 license. This PR sets the license code to "Apache-2.0".