### PR TITLE
Use upper bound for PHP version contraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   },
   "require": {
-    "php": ">=8.0"
+    "php": "^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5"


### PR DESCRIPTION
Using `>=8.0` as a version constraint for PHP can cause potential issues when the attribute syntax changes in future PHP versions, e.g in version 9 or 10. 